### PR TITLE
feat(frontend): Playwright E2E smoke tests (Sprint 7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ With the backend running (e.g. `cd backend && uvicorn app.main:app --reload`):
 
 Without a server (in-process): `cd backend && pytest tests/test_smoke.py -v`
 
+### Frontend E2E (Playwright)
+
+With the frontend running (e.g. `cd frontend && npm run dev`):
+
+```bash
+cd frontend
+npx playwright install   # one-time: install browser binaries
+npm run e2e              # run smoke tests (home, login link, dashboard redirect)
+npm run e2e:ui           # run with Playwright UI
+```
+
+Set `PLAYWRIGHT_BASE_URL` to point at a different origin (e.g. `http://localhost:3000`).
+
 ## Development
 
 ### Getting Started

--- a/dev-doc/SPRINT_PLAN.md
+++ b/dev-doc/SPRINT_PLAN.md
@@ -25,7 +25,7 @@
 **Sprint 6**: ✅ COMPLETE  
 - Export CSV loading state, API docs in README, smoke tests (pytest + script), watchlist migration idempotent, Deal type filter on Analytics
 
-**Next**: Sprint 7 – Enhancements & next features
+**Next**: Sprint 7 – Wrap up E2E PR (#38) and move into Sprint 8 (Admin Module)
 
 ---
 
@@ -81,7 +81,7 @@ Complete foundation setup and basic backend/frontend structure
 - [x] Backend tests for block_deals and short_selling APIs
 - [x] Full filtered export (GET …/export-csv with filters, all segments)
 - [x] Password reset flow (forgot-password + reset-password pages)
-- [ ] Tune NSE short-selling response keys if API shape differs (optional, when needed)
+- [x] Tune NSE short-selling response keys + normalize BUY/SELL (implemented later in Sprint 7)
 
 ---
 
@@ -103,9 +103,86 @@ Add small enhancements and prepare for larger backlog items.
 
 ### Tasks
 - [x] Document smoke test and migrations in README (scripts/smoke_test_backend.sh, pytest test_smoke.py, supabase/MIGRATIONS.md)
-- [x] E2E test (Playwright: smoke – home, login link, dashboard redirect)
-- [ ] NSE short-selling response keys tune-up when API shape is confirmed
-- [ ] Other PRD items: AI Analyzer, admin panel, subscription tiers (as prioritized)
+- [ ] E2E test (Playwright smoke) (PR #38 open): home loads, Sign In → /login, /dashboard → /login when unauthenticated
+- [x] NSE short-selling response keys tune-up: handle key variants + normalize Bought/Sold → BUY/SELL (merged in PR #36)
+- [ ] Decide when to run Playwright in CI (optional): manual/local only vs add a GitHub Action job
+- [ ] Other PRD items (as prioritized): AI Analyzer, admin panel, subscription tiers
+
+---
+
+## Sprint 8: Admin Module (Planned)
+
+### Goal
+Admin can manage system and users (basic back-office).
+
+### Tasks
+- [ ] Define admin roles/permissions (Supabase roles/claims) and RLS strategy
+- [ ] Backend admin endpoints: user management, data management, system settings
+- [ ] Frontend admin area (route group) with basic dashboard + tables
+- [ ] Audit logging for admin actions (who/what/when)
+
+---
+
+## Sprint 9: AI Analyzer (Planned)
+
+### Goal
+AI-powered natural language querying and insights over deals data.
+
+### Tasks
+- [ ] AI SDK setup + server route for streaming chat
+- [ ] Define tool-calls for “query deals / stats / explanations”
+- [ ] AI Analyzer UI: chat interface, suggested prompts, loading/streaming UX
+- [ ] Safety: rate limits, prompt injection guardrails, logging
+
+---
+
+## Sprint 10: Monetization (Planned)
+
+### Goal
+Subscription tiers, feature gating, and billing pages.
+
+### Tasks
+- [ ] Subscription plans and gating rules (free/pro/etc.)
+- [ ] Stripe integration + webhook handling
+- [ ] Billing UI (manage subscription, invoices)
+- [ ] Referral system (optional)
+
+---
+
+## Sprint 11: Security & Polish (Planned)
+
+### Goal
+Hardening, performance, and quality gates.
+
+### Tasks
+- [ ] Expand test coverage (unit + integration) and add a minimal E2E CI gate if desired
+- [ ] Observability: structured logging, request IDs, error tracking
+- [ ] Performance tuning: pagination defaults, DB indexes, caching strategy (if needed)
+- [ ] Documentation: testing guide, runbooks, onboarding
+
+---
+
+## Sprint 12: Marketing Website (Planned / Optional)
+
+### Goal
+Public landing pages, docs/resources, and SEO.
+
+### Tasks
+- [ ] Landing page + feature pages
+- [ ] Blog/resources (optional)
+- [ ] Help center/FAQ (optional)
+
+---
+
+## Sprint 13: Launch Preparation (Planned)
+
+### Goal
+Prepare for production release workflow.
+
+### Tasks
+- [ ] Staging validation checklist + release checklist
+- [ ] Load testing + security audit pass
+- [ ] Final bug-fix sprint
 
 ---
 
@@ -182,6 +259,7 @@ Based on `dev-doc/BRANCH_STRATEGY.md`:
 
 1. **Apply migrations** (if not done): `supabase db push`. See [supabase/MIGRATIONS.md](../supabase/MIGRATIONS.md).
 2. **Verify backend**: Run `./scripts/smoke_test_backend.sh` with backend up, or `cd backend && pytest tests/test_smoke.py -v`.
-3. **Sprint 7**: Next pick — E2E (Playwright), NSE short-selling tune-up, or a PRD feature (AI Analyzer, admin, etc.).
-4. **Optional**: GitHub Project board and Sprint 7 issues.
+3. **Sprint 7**: Merge PR #38 (Playwright E2E smoke) and (optional) decide CI strategy for E2E.
+4. **Sprint 8+**: Next pick — Admin Module (Sprint 8) or AI Analyzer (Sprint 9), then Monetization (Sprint 10).
+5. **Optional**: GitHub Project board and Sprint 7 issues.
 

--- a/dev-doc/SPRINT_PLAN.md
+++ b/dev-doc/SPRINT_PLAN.md
@@ -103,7 +103,7 @@ Add small enhancements and prepare for larger backlog items.
 
 ### Tasks
 - [x] Document smoke test and migrations in README (scripts/smoke_test_backend.sh, pytest test_smoke.py, supabase/MIGRATIONS.md)
-- [ ] E2E test (e.g. Playwright: login → Analytics → Export) if desired
+- [x] E2E test (Playwright: smoke – home, login link, dashboard redirect)
 - [ ] NSE short-selling response keys tune-up when API shape is confirmed
 - [ ] Other PRD items: AI Analyzer, admin panel, subscription tiers (as prioritized)
 

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -12,6 +12,9 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
+/playwright/.cache/
 
 # next.js
 /.next/

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Smoke', () => {
+  test('home page loads', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveTitle(/BulkDeal|Bulk Deal|Analyzer/i);
+  });
+
+  test('login page loads from home', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('link', { name: /sign in/i }).first().click();
+    await expect(page).toHaveURL(/\/login/);
+    await expect(
+      page.getByRole('heading', { name: /welcome back/i }),
+    ).toBeVisible();
+  });
+
+  test('dashboard redirects to login when unauthenticated', async ({
+    page,
+  }) => {
+    await page.goto('/dashboard');
+    await expect(page).toHaveURL(/\/login/);
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "recharts": "^3.7.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -1228,6 +1229,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -3977,6 +3994,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -5704,6 +5736,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@supabase/ssr": "^0.8.0",
@@ -18,6 +20,7 @@
     "recharts": "^3.7.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: process.env.CI
+    ? undefined
+    : {
+        command: 'npm run dev',
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+      },
+});


### PR DESCRIPTION
## Summary
Adds Playwright E2E smoke tests for the frontend (Sprint 7).

## Changes
- **playwright.config.ts**: `baseURL` from env or localhost:3000, `e2e` dir, optional `webServer` for local dev
- **e2e/smoke.spec.ts**: Home page load (title), Sign In link → login page (Welcome back), unauthenticated /dashboard → /login
- **package.json**: `e2e`, `e2e:ui` scripts
- **.gitignore**: test-results/, playwright-report/, playwright/.cache/
- **README**: Frontend E2E section (playwright install, npm run e2e / e2e:ui)
- **SPRINT_PLAN**: Mark Sprint 7 E2E task complete

## How to run
```bash
cd frontend && npx playwright install chromium && npm run e2e
```
(With `webServer` in config, dev server starts automatically when not in CI.)

Closes/relates to Sprint 7 E2E (Issue #37 if linked).

Made with [Cursor](https://cursor.com)