### PR TITLE
feat(admin): admin role check and /admin/status (Sprint 8, #39)

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -7,6 +7,7 @@ Main router for API version 1 endpoints.
 from fastapi import APIRouter
 
 from app.api.v1 import (
+    admin,
     alerts,
     auth,
     block_deals,
@@ -22,6 +23,7 @@ api_router = APIRouter()
 # Include routers
 api_router.include_router(health.router, prefix="/health", tags=["Health"])
 api_router.include_router(auth.router, prefix="/auth", tags=["Authentication"])
+api_router.include_router(admin.router, prefix="/admin", tags=["Admin"])
 api_router.include_router(profile.router, prefix="/profile", tags=["Profile"])
 api_router.include_router(
     bulk_deals.router,

--- a/backend/app/api/v1/admin.py
+++ b/backend/app/api/v1/admin.py
@@ -1,0 +1,22 @@
+"""
+Admin API
+
+Endpoints for admin-only operations. All routes require user_profiles.role = 'admin'.
+"""
+
+from fastapi import APIRouter
+
+from app.core.auth import CurrentAdminUser
+from app.core.responses import success_response
+
+router = APIRouter()
+
+
+@router.get("/status")
+async def admin_status(_user: CurrentAdminUser):
+    """
+    Confirm current user has admin access.
+
+    Returns 200 with admin: true. Use to guard admin UI or check access.
+    """
+    return success_response(data={"admin": True}, message="Admin access confirmed")

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -11,7 +11,7 @@ from typing import Annotated, Any
 from fastapi import Depends, Header
 
 from app.core.config import get_settings
-from app.core.exceptions import AuthenticationError
+from app.core.exceptions import AuthenticationError, AuthorizationError
 
 
 def _get_supabase_client():
@@ -81,6 +81,24 @@ async def get_optional_user(
         return None
 
 
+async def get_current_admin_user(user: Any = Depends(get_current_user)) -> Any:
+    """
+    Require the current user to have admin role (user_profiles.role = 'admin').
+
+    Use as a FastAPI dependency for admin-only routes.
+    Raises AuthorizationError (403) if the user is not an admin.
+    """
+    from app.services.profile_service import ProfileService
+
+    service = ProfileService()
+    profile = service.get_by_user_id(str(user.id))
+    role = (profile or {}).get("role", "user")
+    if role != "admin":
+        raise AuthorizationError("Admin access required")
+    return user
+
+
 # Type aliases for cleaner dependency injection
 CurrentUser = Annotated[Any, Depends(get_current_user)]
 OptionalUser = Annotated[Any | None, Depends(get_optional_user)]
+CurrentAdminUser = Annotated[Any, Depends(get_current_admin_user)]

--- a/backend/tests/test_api_v1_admin.py
+++ b/backend/tests/test_api_v1_admin.py
@@ -1,0 +1,67 @@
+"""Tests for admin API endpoints (admin role required)."""
+
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+USER_ID = "123e4567-e89b-12d3-a456-426614174000"
+USER_EMAIL = "admin@example.com"
+
+
+def _mock_auth_user():
+    mock_user = MagicMock()
+    mock_user.id = USER_ID
+    mock_user.email = USER_EMAIL
+    mock_user.user_metadata = {}
+    return mock_user
+
+
+def _auth_patch():
+    mock_user = _mock_auth_user()
+    mock_response = MagicMock()
+    mock_response.user = mock_user
+    return patch(
+        "app.core.auth._get_supabase_client",
+        return_value=MagicMock(
+            auth=MagicMock(get_user=MagicMock(return_value=mock_response)),
+        ),
+    )
+
+
+def test_admin_status_unauthenticated():
+    """GET /admin/status without token returns 401."""
+    response = client.get("/api/v1/admin/status")
+    assert response.status_code == 401
+
+
+def test_admin_status_forbidden_when_not_admin():
+    """GET /admin/status with valid user but role != admin returns 403."""
+    with _auth_patch(), patch(
+        "app.services.profile_service.ProfileService.get_by_user_id",
+        return_value={"user_id": USER_ID, "email": USER_EMAIL, "role": "user"},
+    ):
+        response = client.get(
+            "/api/v1/admin/status",
+            headers={"Authorization": "Bearer fake-token"},
+        )
+    assert response.status_code == 403
+    assert "admin" in response.json().get("detail", "").lower() or "Admin" in str(response.json())
+
+
+def test_admin_status_success_when_admin():
+    """GET /admin/status with admin role returns 200 and admin: true."""
+    with _auth_patch(), patch(
+        "app.services.profile_service.ProfileService.get_by_user_id",
+        return_value={"user_id": USER_ID, "email": USER_EMAIL, "role": "admin"},
+    ):
+        response = client.get(
+            "/api/v1/admin/status",
+            headers={"Authorization": "Bearer fake-token"},
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data.get("data", {}).get("admin") is True

--- a/dev-doc/ADMIN_SETUP.md
+++ b/dev-doc/ADMIN_SETUP.md
@@ -1,0 +1,39 @@
+# Admin Role Setup (Sprint 8)
+
+Admin access is determined by the `role` column on `user_profiles` (see migration `20250216000002_user_role.sql`). Only users with `role = 'admin'` can call admin API routes (e.g. `/api/v1/admin/status`).
+
+## How to set a user as admin
+
+### Option 1: Supabase Dashboard (SQL Editor)
+
+1. Open your project → **SQL Editor**.
+2. Run (replace `YOUR_USER_UUID` with the auth user's UUID from **Authentication → Users**):
+
+```sql
+-- Ensure user_profiles row exists, then set role to admin
+INSERT INTO user_profiles (user_id, email, role)
+VALUES ('YOUR_USER_UUID', 'admin@example.com', 'admin')
+ON CONFLICT (user_id) DO UPDATE SET role = 'admin';
+```
+
+### Option 2: By email (if you have a function)
+
+If you prefer to look up by email (from `auth.users`):
+
+```sql
+UPDATE user_profiles
+SET role = 'admin'
+WHERE user_id = (SELECT id FROM auth.users WHERE email = 'admin@example.com' LIMIT 1);
+```
+
+(Ensure the user has already signed up so a row in `user_profiles` exists, or use the INSERT ... ON CONFLICT above after resolving user_id from auth.users.)
+
+## RLS note
+
+- `user_profiles` has RLS: users can only read/update their own row.
+- The backend uses the **service role** (admin client) to read `user_profiles.role` for the current user, so the admin check is done server-side and is secure.
+- Future admin-only tables (e.g. audit log) can use RLS policies that allow access when the user is an admin (e.g. via a helper that checks `user_profiles.role` for `auth.uid()`).
+
+## Verifying admin access
+
+- Call `GET /api/v1/admin/status` with the user's Bearer token. If they are admin, you get `200` and `{"data": {"admin": true}}`. If not, you get `403 Forbidden`.


### PR DESCRIPTION
## Summary
Implements **Issue #39** (Sprint 8): Admin roles and RLS – backend "is admin?" helper and admin-only endpoint.

## Changes
- **auth.py**: `get_current_admin_user` dependency – requires `user_profiles.role = 'admin'` (403 otherwise)
- **GET /api/v1/admin/status**: admin-only endpoint; returns `{ "admin": true }` when authorized
- **dev-doc/ADMIN_SETUP.md**: how to set a user as admin (SQL via Supabase Dashboard)
- **Tests**: 401 unauthenticated, 403 non-admin, 200 admin

Uses existing `user_profiles.role` from migration `20250216000002_user_role.sql`.

Closes #39

Made with [Cursor](https://cursor.com)