### PR TITLE
feat(admin): backend admin API – list users, update role, stats (#40)

### DIFF
--- a/backend/app/api/v1/admin.py
+++ b/backend/app/api/v1/admin.py
@@ -4,12 +4,24 @@ Admin API
 Endpoints for admin-only operations. All routes require user_profiles.role = 'admin'.
 """
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
+from pydantic import BaseModel
 
 from app.core.auth import CurrentAdminUser
 from app.core.responses import success_response
+from app.services.admin_service import AdminService
+
+
+class RoleUpdateBody(BaseModel):
+    """Body for PATCH /admin/users/{user_id}/role."""
+
+    role: str  # 'user' | 'admin' validated in endpoint
 
 router = APIRouter()
+
+
+def _get_admin_service() -> AdminService:
+    return AdminService()
 
 
 @router.get("/status")
@@ -20,3 +32,48 @@ async def admin_status(_user: CurrentAdminUser):
     Returns 200 with admin: true. Use to guard admin UI or check access.
     """
     return success_response(data={"admin": True}, message="Admin access confirmed")
+
+
+@router.get("/users")
+async def list_users(
+    _user: CurrentAdminUser,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    role: str | None = Query(None, pattern="^(user|admin)$"),
+):
+    """
+    List user profiles (admin only). Paginated.
+
+    Optional role filter: user | admin.
+    """
+    service = _get_admin_service()
+    result = service.list_users(page=page, page_size=page_size, role=role)
+    return success_response(data=result, message="Users retrieved")
+
+
+@router.patch("/users/{user_id}/role")
+async def update_user_role(
+    user_id: str,
+    _user: CurrentAdminUser,
+    body: RoleUpdateBody,
+):
+    """
+    Update a user's role (admin only). Body: { "role": "user" | "admin" }.
+    """
+    if body.role not in ("user", "admin"):
+        from app.core.exceptions import BulkDealValidationError
+
+        raise BulkDealValidationError("role must be 'user' or 'admin'")
+    service = _get_admin_service()
+    profile = service.update_user_role(user_id=user_id, role=body.role)
+    return success_response(data=profile, message="Role updated")
+
+
+@router.get("/stats")
+async def admin_stats(_user: CurrentAdminUser):
+    """
+    Simple dashboard stats: user count, bulk_deals count, block_deals count (admin only).
+    """
+    service = _get_admin_service()
+    stats = service.get_stats()
+    return success_response(data=stats, message="Stats retrieved")

--- a/backend/app/services/admin_service.py
+++ b/backend/app/services/admin_service.py
@@ -1,0 +1,90 @@
+"""
+Admin Service
+
+Admin-only operations: list users (from user_profiles), update role, dashboard stats.
+Uses Supabase admin client (bypasses RLS).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.exceptions import DatabaseError, NotFoundError
+
+
+class AdminService:
+    """Service for admin-only database operations."""
+
+    def __init__(self) -> None:
+        from app.core.database import get_supabase_admin_client
+
+        self._client = get_supabase_admin_client()
+
+    def list_users(
+        self,
+        page: int = 1,
+        page_size: int = 20,
+        role: str | None = None,
+    ) -> dict[str, Any]:
+        """
+        List user profiles with pagination (admin only).
+
+        Returns items, total count (approximate), page, page_size.
+        """
+        try:
+            table = self._client.table("user_profiles")
+            query = table.select("id,user_id,email,full_name,role,created_at", count="exact").order(
+                "created_at", desc=True
+            )
+            if role and role in ("user", "admin"):
+                query = query.eq("role", role)
+            page_size = max(1, min(100, page_size))
+            page = max(1, page)
+            lo = (page - 1) * page_size
+            hi = lo + page_size - 1
+            result = query.range(lo, hi).execute()
+            items = result.data or []
+            total = result.count if result.count is not None else len(items)
+            return {
+                "items": items,
+                "total": total,
+                "page": page,
+                "page_size": page_size,
+            }
+        except Exception as e:
+            raise DatabaseError(f"Failed to list users: {e!s}") from e
+
+    def update_user_role(self, user_id: str, role: str) -> dict[str, Any]:
+        """Update a user's role (admin only). role must be 'user' or 'admin'."""
+        if role not in ("user", "admin"):
+            raise ValueError("role must be 'user' or 'admin'")
+        try:
+            table = self._client.table("user_profiles")
+            result = table.update({"role": role}).eq("user_id", user_id).execute()
+            if not result.data:
+                raise NotFoundError("User profile")
+            return result.data[0]
+        except (NotFoundError, ValueError):
+            raise
+        except Exception as e:
+            raise DatabaseError(f"Failed to update role: {e!s}") from e
+
+    def get_stats(self) -> dict[str, Any]:
+        """Return simple counts for admin dashboard (users, bulk_deals, etc.)."""
+        stats: dict[str, Any] = {}
+        try:
+            up = self._client.table("user_profiles").select("id", count="exact").execute()
+            stats["users"] = up.count if up.count is not None else len(up.data or [])
+        except Exception:
+            stats["users"] = 0
+        try:
+            bd = self._client.table("bulk_deals").select("id", count="exact").execute()
+            stats["bulk_deals"] = bd.count if bd.count is not None else len(bd.data or [])
+        except Exception:
+            stats["bulk_deals"] = 0
+        try:
+            bl = self._client.table("block_deals").select("id", count="exact").execute()
+            stats["block_deals"] = bl.count if bl.count is not None else len(bl.data or [])
+        except Exception:
+            stats["block_deals"] = 0
+        return stats

--- a/backend/tests/test_api_v1_admin.py
+++ b/backend/tests/test_api_v1_admin.py
@@ -65,3 +65,114 @@ def test_admin_status_success_when_admin():
     assert response.status_code == 200
     data = response.json()
     assert data.get("data", {}).get("admin") is True
+
+
+def _admin_auth_patch():
+    """Patch auth + profile so current user is admin. Returns (auth_cm, profile_cm)."""
+    return (
+        _auth_patch(),
+        patch(
+            "app.services.profile_service.ProfileService.get_by_user_id",
+            return_value={"user_id": USER_ID, "email": USER_EMAIL, "role": "admin"},
+        ),
+    )
+
+
+def test_admin_list_users_requires_admin():
+    """GET /admin/users without admin returns 403."""
+    with _auth_patch(), patch(
+        "app.services.profile_service.ProfileService.get_by_user_id",
+        return_value={"user_id": USER_ID, "email": USER_EMAIL, "role": "user"},
+    ):
+        response = client.get(
+            "/api/v1/admin/users",
+            headers={"Authorization": "Bearer fake-token"},
+        )
+    assert response.status_code == 403
+
+
+def test_admin_list_users_success():
+    """GET /admin/users with admin returns 200 and items."""
+    auth_cm, profile_cm = _admin_auth_patch()
+    with auth_cm, profile_cm, patch(
+        "app.api.v1.admin._get_admin_service",
+    ) as mock_svc:
+        mock_svc.return_value.list_users.return_value = {
+            "items": [{"user_id": USER_ID, "email": USER_EMAIL, "role": "admin"}],
+            "total": 1,
+            "page": 1,
+            "page_size": 20,
+        }
+        response = client.get(
+            "/api/v1/admin/users",
+            headers={"Authorization": "Bearer fake-token"},
+        )
+    assert response.status_code == 200
+    assert response.json().get("data", {}).get("items") is not None
+
+
+def test_admin_update_role_requires_admin():
+    """PATCH /admin/users/{id}/role without admin returns 403."""
+    with _auth_patch(), patch(
+        "app.services.profile_service.ProfileService.get_by_user_id",
+        return_value={"user_id": USER_ID, "email": USER_EMAIL, "role": "user"},
+    ):
+        response = client.patch(
+            "/api/v1/admin/users/another-uuid/role",
+            json={"role": "admin"},
+            headers={"Authorization": "Bearer fake-token"},
+        )
+    assert response.status_code == 403
+
+
+def test_admin_update_role_success():
+    """PATCH /admin/users/{id}/role with admin returns 200."""
+    auth_cm, profile_cm = _admin_auth_patch()
+    with auth_cm, profile_cm, patch(
+        "app.api.v1.admin._get_admin_service",
+    ) as mock_svc:
+        mock_svc.return_value.update_user_role.return_value = {
+            "user_id": "other-uuid",
+            "email": "u@example.com",
+            "role": "user",
+        }
+        response = client.patch(
+            "/api/v1/admin/users/other-uuid/role",
+            json={"role": "user"},
+            headers={"Authorization": "Bearer fake-token"},
+        )
+    assert response.status_code == 200
+
+
+def test_admin_stats_requires_admin():
+    """GET /admin/stats without admin returns 403."""
+    with _auth_patch(), patch(
+        "app.services.profile_service.ProfileService.get_by_user_id",
+        return_value={"user_id": USER_ID, "email": USER_EMAIL, "role": "user"},
+    ):
+        response = client.get(
+            "/api/v1/admin/stats",
+            headers={"Authorization": "Bearer fake-token"},
+        )
+    assert response.status_code == 403
+
+
+def test_admin_stats_success():
+    """GET /admin/stats with admin returns 200 and counts."""
+    auth_cm, profile_cm = _admin_auth_patch()
+    with auth_cm, profile_cm, patch(
+        "app.api.v1.admin._get_admin_service",
+    ) as mock_svc:
+        mock_svc.return_value.get_stats.return_value = {
+            "users": 5,
+            "bulk_deals": 100,
+            "block_deals": 20,
+        }
+        response = client.get(
+            "/api/v1/admin/stats",
+            headers={"Authorization": "Bearer fake-token"},
+        )
+    assert response.status_code == 200
+    data = response.json().get("data", {})
+    assert data.get("users") == 5
+    assert data.get("bulk_deals") == 100


### PR DESCRIPTION
## Summary
Implements **Issue #40** (Sprint 8): Backend admin API – user management, stats.

## Changes
- **AdminService** (`backend/app/services/admin_service.py`): `list_users` (paginated, optional role filter), `update_user_role`, `get_stats` (users, bulk_deals, block_deals counts)
- **GET /api/v1/admin/users**: list user profiles (page, page_size, role query)
- **PATCH /api/v1/admin/users/{user_id}/role**: body `{ "role": "user" | "admin" }`
- **GET /api/v1/admin/stats**: dashboard counts
- **Tests**: 403 when not admin for list/update/stats; 200 with mocked service for admin

Closes #40

Made with [Cursor](https://cursor.com)