### PR TITLE
feat(admin): Frontend admin area + admin setup script/docs (#41)

### DIFF
--- a/dev-doc/ADMIN_SETUP.md
+++ b/dev-doc/ADMIN_SETUP.md
@@ -2,31 +2,74 @@
 
 Admin access is determined by the `role` column on `user_profiles` (see migration `20250216000002_user_role.sql`). Only users with `role = 'admin'` can call admin API routes (e.g. `/api/v1/admin/status`).
 
-## How to set a user as admin
+## Prerequisites
 
-### Option 1: Supabase Dashboard (SQL Editor)
+- The user must have **signed up at least once** so a row exists in `user_profiles` (created on first login/signup via your app).
 
-1. Open your project → **SQL Editor**.
-2. Run (replace `YOUR_USER_UUID` with the auth user's UUID from **Authentication → Users**):
+---
+
+## If you get: column "role" of relation "user_profiles" does not exist
+
+The `role` column is added by migration `20250216000002_user_role.sql`. If you haven’t applied it (e.g. via `supabase db push`), run this **once** in the Supabase Dashboard → **SQL Editor**:
 
 ```sql
--- Ensure user_profiles row exists, then set role to admin
-INSERT INTO user_profiles (user_id, email, role)
-VALUES ('YOUR_USER_UUID', 'admin@example.com', 'admin')
-ON CONFLICT (user_id) DO UPDATE SET role = 'admin';
+-- Add role column (safe to run multiple times)
+ALTER TABLE user_profiles
+ADD COLUMN IF NOT EXISTS role VARCHAR(20) NOT NULL DEFAULT 'user'
+CHECK (role IN ('user', 'admin'));
+
+CREATE INDEX IF NOT EXISTS idx_user_profiles_role ON user_profiles(role);
+COMMENT ON COLUMN user_profiles.role IS 'User role: user (default) or admin for admin panel access';
 ```
 
-### Option 2: By email (if you have a function)
+Then run the “Set admin by email” or “Set admin by user UUID” SQL below.
 
-If you prefer to look up by email (from `auth.users`):
+---
+
+## Steps to perform (choose one)
+
+### Option A: Script (recommended if you have backend env)
+
+1. Ensure `backend/.env` has:
+   - `SUPABASE_URL` (e.g. `https://xxxx.supabase.co`)
+   - `SUPABASE_SERVICE_ROLE_KEY` (Supabase Dashboard → **Settings → API** → `service_role` secret)
+
+2. From the **repo root** run:
+
+```bash
+python3 scripts/set_admin_by_email.py your-admin@example.com
+```
+
+3. You should see: `OK: Set role to 'admin' for: your-admin@example.com`
+
+### Option B: Supabase Dashboard (SQL Editor)
+
+1. Open your project in [Supabase Dashboard](https://supabase.com/dashboard) → **SQL Editor** → New query.
+
+2. **Set admin by email** (use when the user has already signed up and has a `user_profiles` row):
 
 ```sql
 UPDATE user_profiles
 SET role = 'admin'
-WHERE user_id = (SELECT id FROM auth.users WHERE email = 'admin@example.com' LIMIT 1);
+WHERE email = 'your-admin@example.com';
 ```
 
-(Ensure the user has already signed up so a row in `user_profiles` exists, or use the INSERT ... ON CONFLICT above after resolving user_id from auth.users.)
+Replace `your-admin@example.com` with the user’s email. Check “Rows affected” (should be 1). If 0, the user has no profile yet—have them sign in once, or use the “By user UUID” method below.
+
+3. **Set admin by user UUID** (use when there is no profile row yet, or you prefer to use the auth user id):
+
+- Go to **Authentication** → **Users** and copy the user’s **UUID** (e.g. `a1b2c3d4-e5f6-7890-abcd-ef1234567890`).
+- Run (replace the UUID and email):
+
+```sql
+INSERT INTO user_profiles (user_id, email, role)
+VALUES ('a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'your-admin@example.com', 'admin')
+ON CONFLICT (user_id) DO UPDATE SET role = 'admin';
+```
+
+This creates the profile if missing, or updates `role` to `admin` if the row already exists.
+
+---
 
 ## RLS note
 
@@ -36,4 +79,5 @@ WHERE user_id = (SELECT id FROM auth.users WHERE email = 'admin@example.com' LIM
 
 ## Verifying admin access
 
-- Call `GET /api/v1/admin/status` with the user's Bearer token. If they are admin, you get `200` and `{"data": {"admin": true}}`. If not, you get `403 Forbidden`.
+- **In the app:** Log in as that user → you should see **Admin** in the sidebar → open it to see the admin dashboard and users table.
+- **API:** Call `GET /api/v1/admin/status` with the user's Bearer token. If they are admin, you get `200` and `{"data": {"admin": true}}`. If not, you get `403 Forbidden`.

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -9,30 +9,100 @@ import { useProfile } from '@/hooks/useProfile';
 import { api } from '@/lib/api';
 import { DashboardSidebar } from '@/components/dashboard/DashboardSidebar';
 
-interface DealStats {
-  total_deals: number;
-  buy_deals: number;
-  sell_deals: number;
+interface AdminStats {
+  users: number;
+  bulk_deals: number;
+  block_deals: number;
+}
+
+interface AdminUser {
+  id: string;
+  user_id: string;
+  email: string | null;
+  full_name: string | null;
+  role: string;
+  created_at: string;
+}
+
+interface AdminUsersResponse {
+  items: AdminUser[];
+  total: number;
+  page: number;
+  page_size: number;
 }
 
 export default function AdminPage() {
   const router = useRouter();
   const { user, signOut, getAccessToken } = useAuth();
-  const { isAdmin, loading: profileLoading } = useProfile();
-  const [stats, setStats] = useState<DealStats | null>(null);
-  const [loading, setLoading] = useState(true);
+  const { isAdmin, loading: profileLoading, refetch: refetchProfile } = useProfile();
+  const [adminStatusOk, setAdminStatusOk] = useState<boolean | null>(null);
+  const [stats, setStats] = useState<AdminStats | null>(null);
+  const [usersData, setUsersData] = useState<AdminUsersResponse | null>(null);
+  const [usersPage, setUsersPage] = useState(1);
+  const [usersRoleFilter, setUsersRoleFilter] = useState<string>('');
+  const [loadingStats, setLoadingStats] = useState(true);
+  const [loadingUsers, setLoadingUsers] = useState(true);
+  const [updatingRoleFor, setUpdatingRoleFor] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const pageSize = 20;
+
+  const fetchAdminStatus = useCallback(async () => {
+    try {
+      const token = await getAccessToken();
+      const data = await api.get<{ admin: boolean }>('/admin/status', token ?? undefined);
+      setAdminStatusOk(data?.admin === true);
+    } catch {
+      setAdminStatusOk(false);
+    }
+  }, [getAccessToken]);
 
   const fetchStats = useCallback(async () => {
     try {
+      setLoadingStats(true);
       const token = await getAccessToken();
-      const data = await api.get<DealStats>('/bulk-deals/stats', token ?? undefined);
-      setStats(data);
+      const data = await api.get<AdminStats>('/admin/stats', token ?? undefined);
+      setStats(data ?? null);
     } catch {
       setStats(null);
     } finally {
-      setLoading(false);
+      setLoadingStats(false);
     }
   }, [getAccessToken]);
+
+  const fetchUsers = useCallback(async () => {
+    try {
+      setLoadingUsers(true);
+      setError(null);
+      const token = await getAccessToken();
+      const params = new URLSearchParams({ page: String(usersPage), page_size: String(pageSize) });
+      if (usersRoleFilter === 'user' || usersRoleFilter === 'admin') params.set('role', usersRoleFilter);
+      const data = await api.get<AdminUsersResponse>(`/admin/users?${params.toString()}`, token ?? undefined);
+      setUsersData(data ?? null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load users');
+      setUsersData(null);
+    } finally {
+      setLoadingUsers(false);
+    }
+  }, [getAccessToken, usersPage, usersRoleFilter]);
+
+  const updateRole = useCallback(
+    async (userId: string, role: 'user' | 'admin') => {
+      try {
+        setUpdatingRoleFor(userId);
+        const token = await getAccessToken();
+        await api.patch<AdminUser>(`/admin/users/${userId}/role`, { role }, token ?? undefined);
+        await fetchUsers();
+        refetchProfile();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to update role');
+      } finally {
+        setUpdatingRoleFor(null);
+      }
+    },
+    [getAccessToken, fetchUsers, refetchProfile]
+  );
 
   useEffect(() => {
     if (profileLoading) return;
@@ -40,8 +110,18 @@ export default function AdminPage() {
       router.replace('/dashboard');
       return;
     }
+    fetchAdminStatus();
+  }, [isAdmin, profileLoading, router, fetchAdminStatus]);
+
+  useEffect(() => {
+    if (adminStatusOk !== true) return;
     fetchStats();
-  }, [isAdmin, profileLoading, router, fetchStats]);
+  }, [adminStatusOk, fetchStats]);
+
+  useEffect(() => {
+    if (adminStatusOk !== true) return;
+    fetchUsers();
+  }, [adminStatusOk, fetchUsers]);
 
   if (profileLoading || !isAdmin) {
     return (
@@ -52,6 +132,23 @@ export default function AdminPage() {
       </ProtectedRoute>
     );
   }
+
+  if (adminStatusOk === null) {
+    return (
+      <ProtectedRoute>
+        <div className="min-h-screen bg-[var(--color-bg-primary)] flex items-center justify-center">
+          <div className="w-10 h-10 border-2 border-[#00d4aa] border-t-transparent rounded-full animate-spin" />
+        </div>
+      </ProtectedRoute>
+    );
+  }
+
+  if (adminStatusOk === false) {
+    router.replace('/dashboard');
+    return null;
+  }
+
+  const totalPages = usersData ? Math.max(1, Math.ceil(usersData.total / pageSize)) : 1;
 
   return (
     <ProtectedRoute>
@@ -65,72 +162,150 @@ export default function AdminPage() {
                 Admin panel
               </span>
             </div>
-            <p className="text-[var(--color-text-secondary)]">System overview and management.</p>
+            <p className="text-[var(--color-text-secondary)]">System overview and user management.</p>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
             <div className="card p-5 border border-[var(--color-border)]">
-              <div className="text-sm text-[var(--color-text-muted)] mb-1">Total deals</div>
+              <div className="text-sm text-[var(--color-text-muted)] mb-1">Users</div>
               <div className="text-2xl font-bold font-mono">
-                {loading ? '—' : stats ? stats.total_deals.toLocaleString() : '0'}
+                {loadingStats ? '—' : stats ? stats.users.toLocaleString() : '0'}
               </div>
             </div>
             <div className="card p-5 border border-[var(--color-border)]">
-              <div className="text-sm text-[var(--color-text-muted)] mb-1">Buy deals</div>
+              <div className="text-sm text-[var(--color-text-muted)] mb-1">Bulk deals</div>
               <div className="text-2xl font-bold font-mono text-[#00d4aa]">
-                {loading ? '—' : stats ? stats.buy_deals.toLocaleString() : '0'}
+                {loadingStats ? '—' : stats ? stats.bulk_deals.toLocaleString() : '0'}
               </div>
             </div>
             <div className="card p-5 border border-[var(--color-border)]">
-              <div className="text-sm text-[var(--color-text-muted)] mb-1">Sell deals</div>
-              <div className="text-2xl font-bold font-mono text-[#ff6b6b]">
-                {loading ? '—' : stats ? stats.sell_deals.toLocaleString() : '0'}
+              <div className="text-sm text-[var(--color-text-muted)] mb-1">Block deals</div>
+              <div className="text-2xl font-bold font-mono text-[#00d4aa]">
+                {loadingStats ? '—' : stats ? stats.block_deals.toLocaleString() : '0'}
               </div>
             </div>
-            <div className="card p-5 border border-[var(--color-border)] flex items-center justify-center">
-              <Link
-                href="/dashboard/analytics"
-                className="text-[#00d4aa] hover:underline font-medium"
+          </div>
+
+          <div className="card border border-[var(--color-border)] overflow-hidden">
+            <div className="p-4 border-b border-[var(--color-border)] flex flex-wrap items-center gap-4">
+              <h2 className="text-lg font-semibold">Users</h2>
+              <select
+                value={usersRoleFilter}
+                onChange={(e) => {
+                  setUsersRoleFilter(e.target.value);
+                  setUsersPage(1);
+                }}
+                className="bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded px-3 py-1.5 text-sm text-[var(--color-text-primary)]"
               >
-                View bulk deals →
-              </Link>
+                <option value="">All roles</option>
+                <option value="user">User</option>
+                <option value="admin">Admin</option>
+              </select>
+              {error && (
+                <span className="text-sm text-red-400">{error}</span>
+              )}
+            </div>
+            <div className="overflow-x-auto">
+              {loadingUsers ? (
+                <div className="p-8 flex justify-center">
+                  <div className="w-8 h-8 border-2 border-[#00d4aa] border-t-transparent rounded-full animate-spin" />
+                </div>
+              ) : usersData?.items?.length ? (
+                <>
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b border-[var(--color-border)] text-left text-[var(--color-text-muted)]">
+                        <th className="p-3 font-medium">Email</th>
+                        <th className="p-3 font-medium">Name</th>
+                        <th className="p-3 font-medium">Role</th>
+                        <th className="p-3 font-medium">Created</th>
+                        <th className="p-3 font-medium">Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {usersData.items.map((u) => (
+                        <tr key={u.id} className="border-b border-[var(--color-border)]">
+                          <td className="p-3 text-[var(--color-text-primary)]">{u.email ?? '—'}</td>
+                          <td className="p-3 text-[var(--color-text-secondary)]">{u.full_name ?? '—'}</td>
+                          <td className="p-3">
+                            <span
+                              className={
+                                u.role === 'admin'
+                                  ? 'px-2 py-0.5 rounded text-xs font-medium bg-amber-500/20 text-amber-400 border border-amber-500/30'
+                                  : 'text-[var(--color-text-secondary)]'
+                              }
+                            >
+                              {u.role}
+                            </span>
+                          </td>
+                          <td className="p-3 text-[var(--color-text-muted)]">
+                            {u.created_at ? new Date(u.created_at).toLocaleDateString() : '—'}
+                          </td>
+                          <td className="p-3">
+                            {u.role === 'admin' ? (
+                              <button
+                                type="button"
+                                onClick={() => updateRole(u.user_id, 'user')}
+                                disabled={updatingRoleFor === u.user_id}
+                                className="text-amber-400 hover:underline disabled:opacity-50 text-xs"
+                              >
+                                {updatingRoleFor === u.user_id ? 'Updating…' : 'Set User'}
+                              </button>
+                            ) : (
+                              <button
+                                type="button"
+                                onClick={() => updateRole(u.user_id, 'admin')}
+                                disabled={updatingRoleFor === u.user_id}
+                                className="text-[#00d4aa] hover:underline disabled:opacity-50 text-xs"
+                              >
+                                {updatingRoleFor === u.user_id ? 'Updating…' : 'Set Admin'}
+                              </button>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                  <div className="p-3 border-t border-[var(--color-border)] flex items-center justify-between flex-wrap gap-2">
+                    <span className="text-sm text-[var(--color-text-muted)]">
+                      {usersData.total} user{usersData.total !== 1 ? 's' : ''}
+                    </span>
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        onClick={() => setUsersPage((p) => Math.max(1, p - 1))}
+                        disabled={usersPage <= 1}
+                        className="px-3 py-1 rounded border border-[var(--color-border)] text-sm disabled:opacity-50 hover:bg-[var(--color-bg-tertiary)]"
+                      >
+                        Previous
+                      </button>
+                      <span className="px-3 py-1 text-sm text-[var(--color-text-secondary)]">
+                        Page {usersData.page} of {totalPages}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => setUsersPage((p) => Math.min(totalPages, p + 1))}
+                        disabled={usersPage >= totalPages}
+                        className="px-3 py-1 rounded border border-[var(--color-border)] text-sm disabled:opacity-50 hover:bg-[var(--color-bg-tertiary)]"
+                      >
+                        Next
+                      </button>
+                    </div>
+                  </div>
+                </>
+              ) : (
+                <div className="p-8 text-center text-[var(--color-text-muted)]">No users found.</div>
+              )}
             </div>
           </div>
 
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <div className="mt-6 flex gap-4">
             <Link
               href="/dashboard/analytics"
-              className="card p-6 border border-[var(--color-border)] hover:border-[var(--color-border-hover)] transition-colors block"
+              className="text-[#00d4aa] hover:underline font-medium text-sm"
             >
-              <div className="flex items-center gap-3 mb-2">
-                <div className="w-10 h-10 rounded-lg bg-[var(--color-bg-tertiary)] flex items-center justify-center">
-                  <svg className="w-5 h-5 text-[var(--color-text-secondary)]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-                  </svg>
-                </div>
-                <h2 className="text-lg font-semibold">Bulk deals</h2>
-              </div>
-              <p className="text-sm text-[var(--color-text-secondary)]">Browse, filter, and manage bulk deals data. Fetch from NSE or upload CSV.</p>
+              View Analytics →
             </Link>
-
-            <Link
-              href="/dashboard/analytics"
-              className="card p-6 border border-[var(--color-border)] hover:border-[var(--color-border-hover)] transition-colors block"
-            >
-              <div className="flex items-center gap-3 mb-2">
-                <div className="w-10 h-10 rounded-lg bg-[var(--color-bg-tertiary)] flex items-center justify-center">
-                  <svg className="w-5 h-5 text-[var(--color-text-secondary)]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-                  </svg>
-                </div>
-                <h2 className="text-lg font-semibold">Fetch history</h2>
-              </div>
-              <p className="text-sm text-[var(--color-text-secondary)]">View NSE fetch history and import logs. Available in Analytics (Bulk Deals tab).</p>
-            </Link>
-          </div>
-
-          <div className="mt-8 p-4 rounded-lg bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] text-sm text-[var(--color-text-muted)]">
-            <strong className="text-[var(--color-text-primary)]">Admin note:</strong> User management and system settings can be added here. For now, use Supabase Dashboard for user and database management.
           </div>
         </main>
       </div>

--- a/scripts/set_admin_by_email.py
+++ b/scripts/set_admin_by_email.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+Set a user as admin by email (user_profiles.role = 'admin').
+
+Requires SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY (e.g. from backend/.env).
+Run from repo root:
+  python scripts/set_admin_by_email.py user@example.com
+"""
+
+import os
+import sys
+from pathlib import Path
+
+# Load backend .env so SUPABASE_* are set
+backend_dir = Path(__file__).resolve().parent.parent / "backend"
+env_file = backend_dir / ".env"
+if env_file.exists():
+    with open(env_file) as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                k, _, v = line.partition("=")
+                k = k.strip()
+                v = v.strip().strip('"').strip("'")
+                if k and k not in os.environ:
+                    os.environ[k] = v
+
+sys.path.insert(0, str(backend_dir))
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 scripts/set_admin_by_email.py <email>")
+        print("Example: python3 scripts/set_admin_by_email.py admin@example.com")
+        sys.exit(1)
+
+    email = sys.argv[1].strip()
+    if not email:
+        print("Error: provide a non-empty email.")
+        sys.exit(1)
+
+    try:
+        from app.core.database import get_supabase_admin_client
+    except Exception as e:
+        print("Error: could not load backend (run from repo root):", e)
+        print("Ensure backend/.env has SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.")
+        sys.exit(1)
+
+    try:
+        client = get_supabase_admin_client()
+    except ValueError as e:
+        print("Error:", e)
+        print("Set SUPABASE_SERVICE_ROLE_KEY in backend/.env (Supabase Dashboard → Settings → API → service_role).")
+        sys.exit(1)
+
+    table = client.table("user_profiles")
+    result = table.update({"role": "admin"}).eq("email", email).execute()
+
+    if not result.data or len(result.data) == 0:
+        print("No user_profiles row found for email:", email)
+        print("Have the user sign up once so a profile row exists, then run this again.")
+        print("Or set admin via Supabase Dashboard → SQL Editor (see dev-doc/ADMIN_SETUP.md).")
+        sys.exit(1)
+
+    print("OK: Set role to 'admin' for:", email)
+    print("They can now use the Admin panel and GET /api/v1/admin/status.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #41

## Summary
- **Frontend admin area**: Admin route with GET /admin/status check, dashboard stats (users, bulk_deals, block_deals), users table with pagination and role filter, Set Admin/Set User actions.
- **Admin setup**: `scripts/set_admin_by_email.py`, expanded `dev-doc/ADMIN_SETUP.md` (script + SQL options, fix for missing role column).

## Acceptance
- Non-admins redirected from /dashboard/admin; admins see dashboard and users table.
- Stats and users from backend admin API; role updates via PATCH.

Made with [Cursor](https://cursor.com)